### PR TITLE
.circleci/config.yml: uncomment deploy_prod and deploy_dev filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,12 @@ workflows:
     jobs:
       - deploy_dev:
           context: web-cdn-aws-nyulitsdev
-      #    filters:
-      #      branches:
-      #        ignore:
-      #          - main
-      #- deploy_prod:
-      #    context: web-cdn-aws-nyulits
-      #    filters:
-      #      branches:
-      #        only: main
+          filters:
+            branches:
+              ignore:
+                - main
+      - deploy_prod:
+          context: web-cdn-aws-nyulits
+          filters:
+            branches:
+              only: main


### PR DESCRIPTION
Set up deployment to dev and prod CDNs by branch.

NOTE: The CDN files will not be deployed to dev, as there is an in-flight branch that has deployed to dev with CSS that this branch off `main` does not have.  The CircleCI job for deploying to dev from non-`main` branch will be manually (and quickly) canceled after push.  The merge into `main` will be allowed to go through, as currently there are no Primo VE views linked to prod CDN.

EDIT: CircleCI was too slow to load.  This branch has deployed to dev CDN.  Will re-run `reimplement_color_scheme` CircleCI deployment.