### PR TITLE
Update from develop: Add bypassCSP, set to true in E2E playwright.config.js

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -55,7 +55,8 @@ const config = {
   reporter: 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-
+    // Toggle bypassing page's CSP as ExLibris updated their "Content-Security-Policy" to include 'upgrade-insecure-requests'
+    bypassCSP: true,
     /* Browser to use. See https://playwright.dev/docs/api/class-browsertype. */
     /* We are already using only chromium in our projects.
 All tests are run in a headless mode by default */


### PR DESCRIPTION
Updated Playwright configuration by adding` bypassCSP` and setting it to `true`

As ExLibris updated their "Content-Security-Policy" to include "upgrade-insecure-requests"
```
$ curl -I http://primo-explore-devenv:8003/discovery/search
HTTP/1.1 200 OK
x-request-id: GYgVZV5UoG
p3p: CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
set-cookie: JSESSIONID="9E2C2594BF42927CC252AC7970F684E5.apd01.na07.prod.alma.dc01.hosted.exlibrisgroup.com:1801"; Version=1; Path=/; HttpOnly; SameSite=None; Secure
set-cookie: __Secure-UqZBpD3n3naPU20-9Fvn5i-TQ-tFo8hbYtbA9YCEpg3UXgo_=v1ouoKgw__jd6; Expires=Sat, 19-Nov-2033 15:59:10 GMT; Path=/; Secure; SameSite=None
accept-ranges: bytes
etag: W/"4587-1699475796000"
last-modified: Wed, 08 Nov 2023 20:36:36 GMT
cache-control: max-age=0
expires: Wed, 22 Nov 2023 15:59:10 GMT
content-security-policy: object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;
vary: accept-encoding
content-type: text/html;charset=ISO-8859-1
content-length: 4587
date: Wed, 22 Nov 2023 15:59:10 GMT
connection: keep-alive
```