### PR TITLE
Update E2E docker logic

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -19,10 +19,8 @@ COPY unit_tests/ /unit_tests/
 
 # Install unit test dependencies
 WORKDIR /unit_tests
-RUN if [ -f package.json ]; then \
-    yarn install --frozen-lockfile && \
-    yarn cache clean; \
-    fi
+RUN yarn install --frozen-lockfile \
+    && yarn cache clean;
 
 # Return to the e2e directory
 WORKDIR /e2e

--- a/e2e/docker-entrypoint.sh
+++ b/e2e/docker-entrypoint.sh
@@ -6,11 +6,6 @@ cd /unit_tests
 yarn test
 cd .. && cd e2e
 
-# Check if unit tests passed
-if [ $? -ne 0 ]; then
-    echo "Unit tests failed, stopping build."
-    exit 1
-fi
 
 start_time=$(date +%s)
 timeout=30 #seconds

--- a/e2e/testutils/index.js
+++ b/e2e/testutils/index.js
@@ -38,9 +38,9 @@ async function modifyCSPHeader(page) {
         let csp = originalHeaders['content-security-policy'];
         if (csp && csp.includes('upgrade-insecure-requests')) {
 
-            let directives = csp.split(';').map(dir => dir.trim());
+            let directives = csp.split(';').map(directive => directive.trim());
 
-            directives = directives.filter(dir => !dir.toLowerCase().includes('upgrade-insecure-requests'));
+            directives = directives.filter(directive => !directive.toLowerCase().includes('upgrade-insecure-requests'));
 
             csp = directives.join('; ').trim();
         }


### PR DESCRIPTION
This pull request contains the following specific changes:

**Streamlined Script Execution in docker-entrypoint.sh**
Removed a manual check for unit test pass/fail status. Given the presence of the -e flag in the shebang (#!/bin/sh -e), the script will automatically exit on any command that fails, making the explicit check for unit test failure unnecessary. 

**Removed Redundant package.json Check in Dockerfile**
A superfluous check for package.json has been removed from the Dockerfile. 

**Improved Code Readability by Renaming Parameter in testutils.js**
Updated the testutils.js file by renaming the dir parameter to directive. This change is intended to provide better context and improve readability, ensuring that the purpose of the parameter is immediately clear to anyone reading the code.