### PR TITLE
Modify modifyCSPHeader function

### DIFF
--- a/e2e/testutils/index.js
+++ b/e2e/testutils/index.js
@@ -47,16 +47,15 @@ async function modifyCSPHeader(page) {
             csp = directives.length > 0 ? directives.join('; ').trim() : '';
         }
 
-        let headersForFulfill = { ...originalHeaders };
-        if ( csp !== undefined ) {
-            headersForFulfill['content-security-policy'] = csp;
-        } else {
-            delete headersForFulfill['content-security-policy'];
-        }
-
         route.fulfill({
             response,
-            headers: headersForFulfill
+            headers: {
+                ...originalHeaders,
+                // Setting the CSP header to undefined removes it
+                // See usage in https://playwright.dev/docs/api/class-route#route-continue
+                // if 'originalHeaders['content-security-policy']' is undefined, the header is removed
+                'content-security-policy': csp != null ? csp : originalHeaders['content-security-policy']
+            }
         });
     });
 }

--- a/e2e/testutils/index.js
+++ b/e2e/testutils/index.js
@@ -38,6 +38,9 @@ async function modifyCSPHeader(page) {
 
         // Prepare the modified CSP header, if necessary
         let csp = originalHeaders['content-security-policy'];
+        if ( !csp ) {
+            return;
+        }
         if ( csp && csp.toLowerCase().includes('upgrade-insecure-requests') ) {
 
             let directives = csp.split(';').map(directive => directive.trim());
@@ -51,10 +54,7 @@ async function modifyCSPHeader(page) {
             response,
             headers: {
                 ...originalHeaders,
-                // Setting the CSP header to undefined removes it
-                // See usage in https://playwright.dev/docs/api/class-route#route-continue
-                // if 'originalHeaders['content-security-policy']' is undefined, the header is removed
-                'content-security-policy': csp != null ? csp : originalHeaders['content-security-policy']
+                'content-security-policy': csp
             }
         });
     });

--- a/unit_tests/index.spec.js
+++ b/unit_tests/index.spec.js
@@ -50,7 +50,7 @@ describe('modifyCSPHeader', () => {
     expect(route.fulfill).toHaveBeenCalledTimes(1);
   });
 
-  it('should not include content-security-policy in headers if set to undefined', async () => {
+  it('should not include content-security-policy in csp if header is undefined', async () => {
     // Mock response headers with CSP header set to undefined
     const headersWithCSPUndefined = {
       'content-security-policy': undefined,
@@ -72,17 +72,12 @@ describe('modifyCSPHeader', () => {
     await modifyCSPHeader(page);
 
     // Assertions
+   // Assertions
     expect(page).toBeDefined();
     expect(page).toBeTruthy();
     expect(route.fetch).toHaveBeenCalled();
     expect(route.fetch).toHaveBeenCalledTimes(1);
-    expect(route.fulfill).toHaveBeenCalledWith({
-      response: expect.anything(),
-      headers: expect.not.objectContaining({
-        'content-security-policy': expect.anything()
-      })
-    });
-    expect(route.fulfill).toHaveBeenCalledTimes(1);
+    expect(route.fulfill).not.toHaveBeenCalled();
   });
 
   it('should not alter CSP header if upgrade-insecure-requests is not present', async () => {

--- a/unit_tests/index.spec.js
+++ b/unit_tests/index.spec.js
@@ -79,7 +79,7 @@ describe('modifyCSPHeader', () => {
     expect(route.fulfill).toHaveBeenCalledWith({
       response: expect.anything(),
       headers: expect.not.objectContaining({
-        'content-security-policy': undefined
+        'content-security-policy': expect.anything()
       })
     });
     expect(route.fulfill).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR contains the following updates to the modifyCSPHeader function:

- Early Return Optimization: Added an early return if the content-security-policy (CSP) header is not present in the response. 

- Streamlined Header Handling: Simplified the header modification process. Instead of creating a new headers object (headersForFulfill), the original headers object is now directly updated. This change reduces complexity and enhances code maintainability.

- Refined Conditional Logic: The redundant check for csp being non-null is eliminated, streamlining the logic flow.

Update of unit tests 