### PR TITLE
e2e/testutils/index.js: remove obsolete `csp` truthy check

### DIFF
--- a/e2e/testutils/index.js
+++ b/e2e/testutils/index.js
@@ -38,8 +38,12 @@ async function modifyCSPHeader(page) {
 
         // Prepare the modified CSP header, if necessary
         let csp = originalHeaders['content-security-policy'];
+        // If original response did not have a CSP header, there's nothing to do,
+        // just pass through.
+        // TODO: Once the Jest tests have a `route.continue()` mock, change this
+        // to `return route.continue()`.
         if ( !csp ) {
-            route.fulfill({ headers: originalHeaders } );
+            return route.fulfill( {  response, headers: originalHeaders } );
         }
         if ( csp.toLowerCase().includes('upgrade-insecure-requests') ) {
 

--- a/e2e/testutils/index.js
+++ b/e2e/testutils/index.js
@@ -41,7 +41,7 @@ async function modifyCSPHeader(page) {
         if ( !csp ) {
             route.fulfill({ headers: originalHeaders } );
         }
-        if ( csp && csp.toLowerCase().includes('upgrade-insecure-requests') ) {
+        if ( csp.toLowerCase().includes('upgrade-insecure-requests') ) {
 
             let directives = csp.split(';').map(directive => directive.trim());
 


### PR DESCRIPTION
* Removed a `csp` truthy check that occurs after early exit as it's already guaranteed to be truthy at that point.
* Put `route.fulfill` in a `return` statement to stop execution.
* Added a TODO comment to change the `route.fulfill(...)` in the early exit to `route.continue()` after the Jest mock for `route.continue` has been made and the test updated.