### PR TITLE
Implement return route continue

### DIFF
--- a/e2e/testutils/index.js
+++ b/e2e/testutils/index.js
@@ -40,10 +40,8 @@ async function modifyCSPHeader(page) {
         let csp = originalHeaders['content-security-policy'];
         // If original response did not have a CSP header, there's nothing to do,
         // just pass through.
-        // TODO: Once the Jest tests have a `route.continue()` mock, change this
-        // to `return route.continue()`.
         if ( !csp ) {
-            return route.fulfill( {  response, headers: originalHeaders } );
+            return route.continue();
         }
         if ( csp.toLowerCase().includes('upgrade-insecure-requests') ) {
 


### PR DESCRIPTION
This PR modifies the existing conditional statement `if( !csp )` in modifyCPHeader to use `route.continue()` method