### PR TITLE
Pseudo-DRY NYU views custom.js files

### DIFF
--- a/primo-customization/01NYU_AD-AD/js/custom.js
+++ b/primo-customization/01NYU_AD-AD/js/custom.js
@@ -46,13 +46,13 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
-function insertChatwidgetEmbed() {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[ 0 ];
-    x.parentNode.insertBefore( s, x );
+function insertChatWidgetEmbed() {
+    // Always use prod URL for all views.
+    const CHATWIDGET_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', CHATWIDGET_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
 }
 
 // out-of-the-box script except for siteId var
@@ -142,6 +142,6 @@ function findingAidsLinkClickHandler( event ) {
 // ****************************************
 
 configureAndInjectLibKey();
-insertChatwidgetEmbed();
+insertChatWidgetEmbed();
 injectStatusEmbed();
 installMatomo();

--- a/primo-customization/01NYU_AD-AD/js/custom.js
+++ b/primo-customization/01NYU_AD-AD/js/custom.js
@@ -55,6 +55,36 @@ function insertChatwidgetEmbed() {
     x.parentNode.insertBefore( s, x );
 }
 
+// out-of-the-box script except for siteId var
+function injectMatomo( siteId ) {
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
+}
+
+function injectStatusEmbed() {
+    // Always use prod URL for all views:
+    // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
+}
+
 // This function has been made identical for all NYU views in order to make the
 // custom JS file as pseudo-DRY as possible, allowing us to make changes to one
 // view's JS file and simply copy it as-is into the other views.  Toward this
@@ -94,33 +124,8 @@ function installMatomo() {
     }
 
     console.log( '[DEBUG] matomo siteId = ' + siteId );
-    // out-of-the-box script except for siteId var
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push( [ 'trackPageView' ] );
-    _paq.push( [ 'enableLinkTracking' ] );
-    (
-        function () {
-            var u = 'https://nyulib.matomo.cloud/';
-            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
-            _paq.push( [ 'setSiteId', siteId ] );
-            var d = document, g = d.createElement( 'script' ),
-                s = d.getElementsByTagName( 'script' )[ 0 ];
-            g.async = true;
-            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
-            s.parentNode.insertBefore( g, s );
-        }
-    )();
-}
 
-function injectStatusEmbed() {
-    // Always use prod URL for all views:
-    // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL =
-        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
-    const scriptTag = document.createElement( 'script' );
-    scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
-    document.body.appendChild( scriptTag )
+    injectMatomo( siteId );
 }
 
 // ****************************************
@@ -138,5 +143,5 @@ function findingAidsLinkClickHandler( event ) {
 
 configureAndInjectLibKey();
 insertChatwidgetEmbed();
-installMatomo();
 injectStatusEmbed();
+installMatomo();

--- a/primo-customization/01NYU_AD-AD/js/custom.js
+++ b/primo-customization/01NYU_AD-AD/js/custom.js
@@ -1,6 +1,5 @@
 // Option 2 from:
 //     https://thirdiron.atlassian.net/wiki/spaces/BrowZineAPIDocs/pages/79200260/Ex+Libris+Primo+Integration
-
 function configureAndInjectLibKey() {
 // Begin BrowZine - Primo Integration...
     window.browzine = {
@@ -47,69 +46,97 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
+function insertChatwidgetEmbed() {
+    var s = document.createElement( 'script' );
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    var x = document.getElementsByTagName( 'script' )[ 0 ];
+    x.parentNode.insertBefore( s, x );
+}
+
+// This function has been made identical for all NYU views in order to make the
+// custom JS file as pseudo-DRY as possible, allowing us to make changes to one
+// view's JS file and simply copy it as-is into the other views.  Toward this
+// end, we need a full map of vids to Matomo siteIds, even though technically
+// each view only needs to know about its own 2-3 siteIds.
+function installMatomo() {
+    // Source:
+    //     "Matomo JS Tracking Codes for Primo VE NYU Views"
+    //     https://docs.google.com/document/d/1Rmmn1q7zNJxm-Ps0uyxbZ1o_GH4YY8hSUFUgQF9AgmU/edit#heading=h.ovisp1bygp5s
+    const SITE_ID = {
+        '01NYU_AD:AD'     : '7',
+        '01NYU_AD:AD_DEV' : '10',
+
+        '01NYU_INST:NYU'     : '6',
+        '01NYU_INST:NYU_DEV' : '9',
+
+        '01NYU_US:SH'     : '8',
+        '01NYU_US:SH_DEV' : '11',
+    }
+
+    // determine vid from querystring
+    // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
+    const vid =
+        new URLSearchParams( window.location.search )
+            .get( 'vid' );
+    console.log( '[DEBUG] vid = ' + vid );
+
+    // if we're on localhost or primo-explore-devenv, don't install
+    if ( location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname === 'primo-explore-devenv' ) {
+        return;
+    }
+
+    const siteId = SITE_ID[ vid ];
+    if ( !siteId ) {
+        console.error( `[ERROR] No siteId found for vid=${ vid }` );
+        return;
+    }
+
+    console.log( '[DEBUG] matomo siteId = ' + siteId );
+    // out-of-the-box script except for siteId var
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
+}
+
 function injectStatusEmbed() {
     // Always use prod URL for all views:
     // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL
-        = 'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
     const scriptTag = document.createElement( 'script' );
     scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
     document.body.appendChild( scriptTag )
 }
 
-configureAndInjectLibKey();
-injectStatusEmbed();
+// ****************************************
+// Event handlers
+// ****************************************
 
 // used in html/prm-brief-result-after.html
 function findingAidsLinkClickHandler( event ) {
     event.stopPropagation();
 }
 
-// chatwidget-embed
-( function () {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[0];
-    x.parentNode.insertBefore( s, x );
-} )();
+// ****************************************
+// MAIN
+// ****************************************
 
-(function(){
-    function installMatomo() {
-        // determine vid from querystring
-        // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
-        const vid = (new URLSearchParams(window.location.search)).get("vid");
-        console.log("[DEBUG] vid = " + vid);
-
-        // if we're on localhost or primo-explore-devenv, don't install
-        if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname === "primo-explore-devenv") {
-            return;
-        }
-
-        // if dev, use dev matomo
-        var siteId;
-        if (vid === "01NYU_AD:AD_DEV") {
-            siteId = '10';
-        // otherwise, assume we're in prod
-        } else {
-            siteId = '7';
-        }
-        console.log("[DEBUG] matomo siteId = " + siteId);
-        // out-of-the-box script except for siteId var
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-            var u="https://nyulib.matomo.cloud/";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', siteId]);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src='//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    }
-
-    // no "DOM ready" check needed since this script is added by view package only after DOM is ready
-    installMatomo();
-})();
+configureAndInjectLibKey();
+insertChatwidgetEmbed();
+installMatomo();
+injectStatusEmbed();

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -56,7 +56,26 @@ function insertChatwidgetEmbed() {
     x.parentNode.insertBefore( s, x );
 }
 
+// This function has been made identical for all NYU views in order to make the
+// custom JS file as pseudo-DRY as possible, allowing us to make changes to one
+// view's JS file and simply copy it as-is into the other views.  Toward this
+// end, we need a full map of vids to Matomo siteIds, even though technically
+// each view only needs to know about its own 2-3 siteIds.
 function installMatomo() {
+    // Source:
+    //     "Matomo JS Tracking Codes for Primo VE NYU Views"
+    //     https://docs.google.com/document/d/1Rmmn1q7zNJxm-Ps0uyxbZ1o_GH4YY8hSUFUgQF9AgmU/edit#heading=h.ovisp1bygp5s
+    const SITE_ID = {
+        '01NYU_AD:AD'     : '7',
+        '01NYU_AD:AD_DEV' : '10',
+
+        '01NYU_INST:NYU'     : '6',
+        '01NYU_INST:NYU_DEV' : '9',
+
+        '01NYU_US:SH'     : '8',
+        '01NYU_US:SH_DEV' : '11',
+    }
+
     // determine vid from querystring
     // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
     const vid =
@@ -69,14 +88,12 @@ function installMatomo() {
         return;
     }
 
-    // if dev, use dev matomo
-    var siteId;
-    if ( vid === '01NYU_INST:NYU_DEV' ) {
-        siteId = '9';
-        // otherwise, assume we're in prod
-    } else {
-        siteId = '6';
+    const siteId = SITE_ID[ vid ];
+    if ( !siteId ) {
+        console.error( `[ERROR] No siteId found for vid=${ vid }` );
+        return;
     }
+
     console.log( '[DEBUG] matomo siteId = ' + siteId );
     // out-of-the-box script except for siteId var
     var _paq = window._paq = window._paq || [];

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -123,11 +123,18 @@ function injectStatusEmbed() {
     document.body.appendChild( scriptTag )
 }
 
+// ****************************************
+// Event handlers
+// ****************************************
 
 // used in html/prm-brief-result-after.html
 function findingAidsLinkClickHandler( event ) {
     event.stopPropagation();
 }
+
+// ****************************************
+// MAIN
+// ****************************************
 
 configureAndInjectLibKey();
 insertChatwidgetEmbed();

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -1,6 +1,5 @@
 // Option 2 from:
 //     https://thirdiron.atlassian.net/wiki/spaces/BrowZineAPIDocs/pages/79200260/Ex+Libris+Primo+Integration
-
 function configureAndInjectLibKey() {
 // Begin BrowZine - Primo Integration...
     window.browzine = {

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -123,13 +123,13 @@ function injectStatusEmbed() {
     document.body.appendChild( scriptTag )
 }
 
-configureAndInjectLibKey();
-insertChatwidgetEmbed();
-installMatomo();
-injectStatusEmbed();
 
 // used in html/prm-brief-result-after.html
 function findingAidsLinkClickHandler( event ) {
     event.stopPropagation();
 }
 
+configureAndInjectLibKey();
+insertChatwidgetEmbed();
+installMatomo();
+injectStatusEmbed();

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -47,6 +47,49 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
+function insertChatwidgetEmbed() {
+    var s = document.createElement( 'script' );
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    var x = document.getElementsByTagName( 'script' )[ 0 ];
+    x.parentNode.insertBefore( s, x );
+}
+
+function installMatomo() {
+    // determine vid from querystring
+    // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
+    const vid = (new URLSearchParams(window.location.search)).get("vid");
+    console.log("[DEBUG] vid = " + vid);
+
+    // if we're on localhost or primo-explore-devenv, don't install
+    if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname === "primo-explore-devenv") {
+        return;
+    }
+
+    // if dev, use dev matomo
+    var siteId;
+    if (vid === "01NYU_INST:NYU_DEV") {
+        siteId = '9';
+        // otherwise, assume we're in prod
+    } else {
+        siteId = '6';
+    }
+    console.log("[DEBUG] matomo siteId = " + siteId);
+    // out-of-the-box script except for siteId var
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://nyulib.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', siteId]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+}
+
 function injectStatusEmbed() {
     // Always use prod URL for all views:
     // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
@@ -58,6 +101,8 @@ function injectStatusEmbed() {
 }
 
 configureAndInjectLibKey();
+insertChatwidgetEmbed();
+installMatomo();
 injectStatusEmbed();
 
 // used in html/prm-brief-result-after.html
@@ -65,51 +110,3 @@ function findingAidsLinkClickHandler( event ) {
     event.stopPropagation();
 }
 
-// chatwidget-embed
-( function () {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[0];
-    x.parentNode.insertBefore( s, x );
-} )();
-
-(function(){
-    function installMatomo() {
-        // determine vid from querystring
-        // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
-        const vid = (new URLSearchParams(window.location.search)).get("vid");
-        console.log("[DEBUG] vid = " + vid);
-
-        // if we're on localhost or primo-explore-devenv, don't install
-        if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname === "primo-explore-devenv") {
-            return;
-        }
-
-        // if dev, use dev matomo
-        var siteId;
-        if (vid === "01NYU_INST:NYU_DEV") {
-            siteId = '9';
-        // otherwise, assume we're in prod
-        } else {
-            siteId = '6';
-        }
-        console.log("[DEBUG] matomo siteId = " + siteId);
-        // out-of-the-box script except for siteId var
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-            var u="https://nyulib.matomo.cloud/";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', siteId]);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src='//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    }
-
-    // no "DOM ready" check needed since this script is added by view package only after DOM is ready
-    installMatomo();
-})();

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -46,13 +46,13 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
-function insertChatwidgetEmbed() {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[ 0 ];
-    x.parentNode.insertBefore( s, x );
+function insertChatWidgetEmbed() {
+    // Always use prod URL for all views.
+    const CHATWIDGET_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', CHATWIDGET_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
 }
 
 // out-of-the-box script except for siteId var
@@ -142,6 +142,6 @@ function findingAidsLinkClickHandler( event ) {
 // ****************************************
 
 configureAndInjectLibKey();
-insertChatwidgetEmbed();
+insertChatWidgetEmbed();
 injectStatusEmbed();
 installMatomo();

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -55,6 +55,36 @@ function insertChatwidgetEmbed() {
     x.parentNode.insertBefore( s, x );
 }
 
+// out-of-the-box script except for siteId var
+function injectMatomo( siteId ) {
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
+}
+
+function injectStatusEmbed() {
+    // Always use prod URL for all views:
+    // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
+}
+
 // This function has been made identical for all NYU views in order to make the
 // custom JS file as pseudo-DRY as possible, allowing us to make changes to one
 // view's JS file and simply copy it as-is into the other views.  Toward this
@@ -94,33 +124,8 @@ function installMatomo() {
     }
 
     console.log( '[DEBUG] matomo siteId = ' + siteId );
-    // out-of-the-box script except for siteId var
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push( [ 'trackPageView' ] );
-    _paq.push( [ 'enableLinkTracking' ] );
-    (
-        function () {
-            var u = 'https://nyulib.matomo.cloud/';
-            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
-            _paq.push( [ 'setSiteId', siteId ] );
-            var d = document, g = d.createElement( 'script' ),
-                s = d.getElementsByTagName( 'script' )[ 0 ];
-            g.async = true;
-            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
-            s.parentNode.insertBefore( g, s );
-        }
-    )();
-}
 
-function injectStatusEmbed() {
-    // Always use prod URL for all views:
-    // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL =
-        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
-    const scriptTag = document.createElement( 'script' );
-    scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
-    document.body.appendChild( scriptTag )
+    injectMatomo( siteId );
 }
 
 // ****************************************
@@ -138,5 +143,5 @@ function findingAidsLinkClickHandler( event ) {
 
 configureAndInjectLibKey();
 insertChatwidgetEmbed();
-installMatomo();
 injectStatusEmbed();
+installMatomo();

--- a/primo-customization/01NYU_INST-NYU/js/custom.js
+++ b/primo-customization/01NYU_INST-NYU/js/custom.js
@@ -59,42 +59,49 @@ function insertChatwidgetEmbed() {
 function installMatomo() {
     // determine vid from querystring
     // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
-    const vid = (new URLSearchParams(window.location.search)).get("vid");
-    console.log("[DEBUG] vid = " + vid);
+    const vid =
+        new URLSearchParams( window.location.search )
+            .get( 'vid' );
+    console.log( '[DEBUG] vid = ' + vid );
 
     // if we're on localhost or primo-explore-devenv, don't install
-    if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname === "primo-explore-devenv") {
+    if ( location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname === 'primo-explore-devenv' ) {
         return;
     }
 
     // if dev, use dev matomo
     var siteId;
-    if (vid === "01NYU_INST:NYU_DEV") {
+    if ( vid === '01NYU_INST:NYU_DEV' ) {
         siteId = '9';
         // otherwise, assume we're in prod
     } else {
         siteId = '6';
     }
-    console.log("[DEBUG] matomo siteId = " + siteId);
+    console.log( '[DEBUG] matomo siteId = ' + siteId );
     // out-of-the-box script except for siteId var
     var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-        var u="https://nyulib.matomo.cloud/";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', siteId]);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
 }
 
 function injectStatusEmbed() {
     // Always use prod URL for all views:
     // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL
-        = 'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
     const scriptTag = document.createElement( 'script' );
     scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
     document.body.appendChild( scriptTag )

--- a/primo-customization/01NYU_INST-TESTWS01/js/custom.js
+++ b/primo-customization/01NYU_INST-TESTWS01/js/custom.js
@@ -46,13 +46,13 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
-function insertChatwidgetEmbed() {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[ 0 ];
-    x.parentNode.insertBefore( s, x );
+function insertChatWidgetEmbed() {
+    // Always use prod URL for all views.
+    const CHATWIDGET_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', CHATWIDGET_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
 }
 
 // out-of-the-box script except for siteId var
@@ -142,6 +142,6 @@ function findingAidsLinkClickHandler( event ) {
 // ****************************************
 
 configureAndInjectLibKey();
-insertChatwidgetEmbed();
+insertChatWidgetEmbed();
 injectStatusEmbed();
 installMatomo();

--- a/primo-customization/01NYU_INST-TESTWS01/js/custom.js
+++ b/primo-customization/01NYU_INST-TESTWS01/js/custom.js
@@ -1,6 +1,5 @@
 // Option 2 from:
 //     https://thirdiron.atlassian.net/wiki/spaces/BrowZineAPIDocs/pages/79200260/Ex+Libris+Primo+Integration
-
 function configureAndInjectLibKey() {
 // Begin BrowZine - Primo Integration...
     window.browzine = {
@@ -47,29 +46,97 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
+function insertChatwidgetEmbed() {
+    var s = document.createElement( 'script' );
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    var x = document.getElementsByTagName( 'script' )[ 0 ];
+    x.parentNode.insertBefore( s, x );
+}
+
+// This function has been made identical for all NYU views in order to make the
+// custom JS file as pseudo-DRY as possible, allowing us to make changes to one
+// view's JS file and simply copy it as-is into the other views.  Toward this
+// end, we need a full map of vids to Matomo siteIds, even though technically
+// each view only needs to know about its own 2-3 siteIds.
+function installMatomo() {
+    // Source:
+    //     "Matomo JS Tracking Codes for Primo VE NYU Views"
+    //     https://docs.google.com/document/d/1Rmmn1q7zNJxm-Ps0uyxbZ1o_GH4YY8hSUFUgQF9AgmU/edit#heading=h.ovisp1bygp5s
+    const SITE_ID = {
+        '01NYU_AD:AD_DEV'  : '10',
+        '01NYU_AD:AD_PROD' : '7',
+
+        '01NYU_INST:NYU_DEV'  : '9',
+        '01NYU_INST:NYU_PROD' : '6',
+
+        '01NYU_US:SH_DEV'  : '11',
+        '01NYU_US:SH_PROD' : '8',
+    }
+
+    // determine vid from querystring
+    // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
+    const vid =
+        new URLSearchParams( window.location.search )
+            .get( 'vid' );
+    console.log( '[DEBUG] vid = ' + vid );
+
+    // if we're on localhost or primo-explore-devenv, don't install
+    if ( location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname === 'primo-explore-devenv' ) {
+        return;
+    }
+
+    const siteId = SITE_ID[ vid ];
+    if ( !siteId ) {
+        console.error( `[ERROR] No siteId found for vid=${ vid }` );
+        return;
+    }
+
+    console.log( '[DEBUG] matomo siteId = ' + siteId );
+    // out-of-the-box script except for siteId var
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
+}
+
 function injectStatusEmbed() {
     // Always use prod URL for all views:
     // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL
-        = 'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
     const scriptTag = document.createElement( 'script' );
     scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
     document.body.appendChild( scriptTag )
 }
 
-configureAndInjectLibKey();
-injectStatusEmbed();
+// ****************************************
+// Event handlers
+// ****************************************
 
+// used in html/prm-brief-result-after.html
 function findingAidsLinkClickHandler( event ) {
     event.stopPropagation();
 }
 
-// chatwidget-embed
-( function () {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[0];
-    x.parentNode.insertBefore( s, x );
-} )();
+// ****************************************
+// MAIN
+// ****************************************
+
+configureAndInjectLibKey();
+insertChatwidgetEmbed();
+installMatomo();
+injectStatusEmbed();

--- a/primo-customization/01NYU_INST-TESTWS01/js/custom.js
+++ b/primo-customization/01NYU_INST-TESTWS01/js/custom.js
@@ -55,46 +55,8 @@ function insertChatwidgetEmbed() {
     x.parentNode.insertBefore( s, x );
 }
 
-// This function has been made identical for all NYU views in order to make the
-// custom JS file as pseudo-DRY as possible, allowing us to make changes to one
-// view's JS file and simply copy it as-is into the other views.  Toward this
-// end, we need a full map of vids to Matomo siteIds, even though technically
-// each view only needs to know about its own 2-3 siteIds.
-function installMatomo() {
-    // Source:
-    //     "Matomo JS Tracking Codes for Primo VE NYU Views"
-    //     https://docs.google.com/document/d/1Rmmn1q7zNJxm-Ps0uyxbZ1o_GH4YY8hSUFUgQF9AgmU/edit#heading=h.ovisp1bygp5s
-    const SITE_ID = {
-        '01NYU_AD:AD_DEV'  : '10',
-        '01NYU_AD:AD_PROD' : '7',
-
-        '01NYU_INST:NYU_DEV'  : '9',
-        '01NYU_INST:NYU_PROD' : '6',
-
-        '01NYU_US:SH_DEV'  : '11',
-        '01NYU_US:SH_PROD' : '8',
-    }
-
-    // determine vid from querystring
-    // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
-    const vid =
-        new URLSearchParams( window.location.search )
-            .get( 'vid' );
-    console.log( '[DEBUG] vid = ' + vid );
-
-    // if we're on localhost or primo-explore-devenv, don't install
-    if ( location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname === 'primo-explore-devenv' ) {
-        return;
-    }
-
-    const siteId = SITE_ID[ vid ];
-    if ( !siteId ) {
-        console.error( `[ERROR] No siteId found for vid=${ vid }` );
-        return;
-    }
-
-    console.log( '[DEBUG] matomo siteId = ' + siteId );
-    // out-of-the-box script except for siteId var
+// out-of-the-box script except for siteId var
+function injectMatomo( siteId ) {
     var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push( [ 'trackPageView' ] );
@@ -123,6 +85,49 @@ function injectStatusEmbed() {
     document.body.appendChild( scriptTag )
 }
 
+// This function has been made identical for all NYU views in order to make the
+// custom JS file as pseudo-DRY as possible, allowing us to make changes to one
+// view's JS file and simply copy it as-is into the other views.  Toward this
+// end, we need a full map of vids to Matomo siteIds, even though technically
+// each view only needs to know about its own 2-3 siteIds.
+function installMatomo() {
+    // Source:
+    //     "Matomo JS Tracking Codes for Primo VE NYU Views"
+    //     https://docs.google.com/document/d/1Rmmn1q7zNJxm-Ps0uyxbZ1o_GH4YY8hSUFUgQF9AgmU/edit#heading=h.ovisp1bygp5s
+    const SITE_ID = {
+        '01NYU_AD:AD'     : '7',
+        '01NYU_AD:AD_DEV' : '10',
+
+        '01NYU_INST:NYU'     : '6',
+        '01NYU_INST:NYU_DEV' : '9',
+
+        '01NYU_US:SH'     : '8',
+        '01NYU_US:SH_DEV' : '11',
+    }
+
+    // determine vid from querystring
+    // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
+    const vid =
+        new URLSearchParams( window.location.search )
+            .get( 'vid' );
+    console.log( '[DEBUG] vid = ' + vid );
+
+    // if we're on localhost or primo-explore-devenv, don't install
+    if ( location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname === 'primo-explore-devenv' ) {
+        return;
+    }
+
+    const siteId = SITE_ID[ vid ];
+    if ( !siteId ) {
+        console.error( `[ERROR] No siteId found for vid=${ vid }` );
+        return;
+    }
+
+    console.log( '[DEBUG] matomo siteId = ' + siteId );
+
+    injectMatomo( siteId );
+}
+
 // ****************************************
 // Event handlers
 // ****************************************
@@ -138,5 +143,5 @@ function findingAidsLinkClickHandler( event ) {
 
 configureAndInjectLibKey();
 insertChatwidgetEmbed();
-installMatomo();
 injectStatusEmbed();
+installMatomo();

--- a/primo-customization/01NYU_US-SH/js/custom.js
+++ b/primo-customization/01NYU_US-SH/js/custom.js
@@ -1,6 +1,5 @@
 // Option 2 from:
 //     https://thirdiron.atlassian.net/wiki/spaces/BrowZineAPIDocs/pages/79200260/Ex+Libris+Primo+Integration
-
 function configureAndInjectLibKey() {
 // Begin BrowZine - Primo Integration...
     window.browzine = {
@@ -47,69 +46,97 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
+function insertChatwidgetEmbed() {
+    var s = document.createElement( 'script' );
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    var x = document.getElementsByTagName( 'script' )[ 0 ];
+    x.parentNode.insertBefore( s, x );
+}
+
+// This function has been made identical for all NYU views in order to make the
+// custom JS file as pseudo-DRY as possible, allowing us to make changes to one
+// view's JS file and simply copy it as-is into the other views.  Toward this
+// end, we need a full map of vids to Matomo siteIds, even though technically
+// each view only needs to know about its own 2-3 siteIds.
+function installMatomo() {
+    // Source:
+    //     "Matomo JS Tracking Codes for Primo VE NYU Views"
+    //     https://docs.google.com/document/d/1Rmmn1q7zNJxm-Ps0uyxbZ1o_GH4YY8hSUFUgQF9AgmU/edit#heading=h.ovisp1bygp5s
+    const SITE_ID = {
+        '01NYU_AD:AD'     : '7',
+        '01NYU_AD:AD_DEV' : '10',
+
+        '01NYU_INST:NYU'     : '6',
+        '01NYU_INST:NYU_DEV' : '9',
+
+        '01NYU_US:SH'     : '8',
+        '01NYU_US:SH_DEV' : '11',
+    }
+
+    // determine vid from querystring
+    // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
+    const vid =
+        new URLSearchParams( window.location.search )
+            .get( 'vid' );
+    console.log( '[DEBUG] vid = ' + vid );
+
+    // if we're on localhost or primo-explore-devenv, don't install
+    if ( location.hostname === 'localhost' || location.hostname === '127.0.0.1' || location.hostname === 'primo-explore-devenv' ) {
+        return;
+    }
+
+    const siteId = SITE_ID[ vid ];
+    if ( !siteId ) {
+        console.error( `[ERROR] No siteId found for vid=${ vid }` );
+        return;
+    }
+
+    console.log( '[DEBUG] matomo siteId = ' + siteId );
+    // out-of-the-box script except for siteId var
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
+}
+
 function injectStatusEmbed() {
     // Always use prod URL for all views:
     // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL
-        = 'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
     const scriptTag = document.createElement( 'script' );
     scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
     document.body.appendChild( scriptTag )
 }
 
-configureAndInjectLibKey();
-injectStatusEmbed();
+// ****************************************
+// Event handlers
+// ****************************************
 
 // used in html/prm-brief-result-after.html
 function findingAidsLinkClickHandler( event ) {
     event.stopPropagation();
 }
 
-// chatwidget-embed
-( function () {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[0];
-    x.parentNode.insertBefore( s, x );
-} )();
+// ****************************************
+// MAIN
+// ****************************************
 
-(function(){
-    function installMatomo() {
-        // determine vid from querystring
-        // note that this will fail in IE 11 and Opera Mini: https://caniuse.com/urlsearchparams
-        const vid = (new URLSearchParams(window.location.search)).get("vid");
-        console.log("[DEBUG] vid = " + vid);
-
-        // if we're on localhost or primo-explore-devenv, don't install
-        if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname === "primo-explore-devenv") {
-            return;
-        }
-
-        // if dev, use dev matomo
-        var siteId;
-        if (vid === "01NYU_US:SH_DEV") {
-            siteId = '11';
-        // otherwise, assume we're in prod
-        } else {
-            siteId = '8';
-        }
-        console.log("[DEBUG] matomo siteId = " + siteId);
-        // out-of-the-box script except for siteId var
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-            var u="https://nyulib.matomo.cloud/";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', siteId]);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src='//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    }
-
-    // no "DOM ready" check needed since this script is added by view package only after DOM is ready
-    installMatomo();
-})();
+configureAndInjectLibKey();
+insertChatwidgetEmbed();
+installMatomo();
+injectStatusEmbed();

--- a/primo-customization/01NYU_US-SH/js/custom.js
+++ b/primo-customization/01NYU_US-SH/js/custom.js
@@ -46,13 +46,13 @@ function configureAndInjectLibKey() {
     document.head.appendChild( browzine.script );
 }
 
-function insertChatwidgetEmbed() {
-    var s = document.createElement( 'script' );
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = 'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
-    var x = document.getElementsByTagName( 'script' )[ 0 ];
-    x.parentNode.insertBefore( s, x );
+function insertChatWidgetEmbed() {
+    // Always use prod URL for all views.
+    const CHATWIDGET_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/chatwidget-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', CHATWIDGET_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
 }
 
 // out-of-the-box script except for siteId var
@@ -142,6 +142,6 @@ function findingAidsLinkClickHandler( event ) {
 // ****************************************
 
 configureAndInjectLibKey();
-insertChatwidgetEmbed();
+insertChatWidgetEmbed();
 injectStatusEmbed();
 installMatomo();

--- a/primo-customization/01NYU_US-SH/js/custom.js
+++ b/primo-customization/01NYU_US-SH/js/custom.js
@@ -55,6 +55,36 @@ function insertChatwidgetEmbed() {
     x.parentNode.insertBefore( s, x );
 }
 
+// out-of-the-box script except for siteId var
+function injectMatomo( siteId ) {
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push( [ 'trackPageView' ] );
+    _paq.push( [ 'enableLinkTracking' ] );
+    (
+        function () {
+            var u = 'https://nyulib.matomo.cloud/';
+            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
+            _paq.push( [ 'setSiteId', siteId ] );
+            var d = document, g = d.createElement( 'script' ),
+                s = d.getElementsByTagName( 'script' )[ 0 ];
+            g.async = true;
+            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
+            s.parentNode.insertBefore( g, s );
+        }
+    )();
+}
+
+function injectStatusEmbed() {
+    // Always use prod URL for all views:
+    // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
+    const STATUS_EMBED_PROD_URL =
+        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
+    const scriptTag = document.createElement( 'script' );
+    scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
+    document.body.appendChild( scriptTag )
+}
+
 // This function has been made identical for all NYU views in order to make the
 // custom JS file as pseudo-DRY as possible, allowing us to make changes to one
 // view's JS file and simply copy it as-is into the other views.  Toward this
@@ -94,33 +124,8 @@ function installMatomo() {
     }
 
     console.log( '[DEBUG] matomo siteId = ' + siteId );
-    // out-of-the-box script except for siteId var
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push( [ 'trackPageView' ] );
-    _paq.push( [ 'enableLinkTracking' ] );
-    (
-        function () {
-            var u = 'https://nyulib.matomo.cloud/';
-            _paq.push( [ 'setTrackerUrl', u + 'matomo.php' ] );
-            _paq.push( [ 'setSiteId', siteId ] );
-            var d = document, g = d.createElement( 'script' ),
-                s = d.getElementsByTagName( 'script' )[ 0 ];
-            g.async = true;
-            g.src = '//cdn.matomo.cloud/nyulib.matomo.cloud/matomo.js';
-            s.parentNode.insertBefore( g, s );
-        }
-    )();
-}
 
-function injectStatusEmbed() {
-    // Always use prod URL for all views:
-    // https://nyu-lib.monday.com/boards/765008773/pulses/5525193850/posts/2571053345
-    const STATUS_EMBED_PROD_URL =
-        'https://cdn.library.nyu.edu/statuspage-embed/index.min.js';
-    const scriptTag = document.createElement( 'script' );
-    scriptTag.setAttribute( 'src', STATUS_EMBED_PROD_URL );
-    document.body.appendChild( scriptTag )
+    injectMatomo( siteId );
 }
 
 // ****************************************
@@ -138,5 +143,5 @@ function findingAidsLinkClickHandler( event ) {
 
 configureAndInjectLibKey();
 insertChatwidgetEmbed();
-installMatomo();
 injectStatusEmbed();
+installMatomo();


### PR DESCRIPTION
Make custom.js in all NYU views identical, so that when we need to make changes in the future, we can edit one file and then simply copy it to the other two views.  This pseudo-DRY-ness will also help with extracting common code later to make things genuinely DRY.

* Change insert/install of chatwidget-embed and matamo: switch from IIFE's to regular named functions
* `installMatomo`
  * Make identical across all views with a full `vid` -> `siteId` map
  * Extract `insertMatomo` to separate our `siteId` selection logic from the out-of-the-box Matomo install code
* `insertChatWidgetEmbed`
  * Capitalize "W" to match name from the [widget's GitHub repo](https://github.com/NYULibraries/chatwidget-embed)
  * Standardize element creation code to match what's done in the previously written <script> injection code in both the package and CDN repos
  * Switch from inserting at the top of the stack of <script> tags to inserting at the bottom of <body>, as instructed in the README.md of the widget repo
  * Remove `type` attribute, per https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#type -- "Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type."
  * Remove `async` attribute as there isn't need for this widget to appear super-fast, and we want to give the page DOM time to settle