### PR TITLE
Update devenv-tls image tag to main

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     networks:
       - primo-customization-cdn-net
   devenv-tls:
-    image: quay.io/nyulibraries/primo-customization-devenv:nyu.primo.exlibrisgroup.com
+    image: quay.io/nyulibraries/primo-customization-devenv:main
     depends_on:
       - cdn-server
     extra_hosts:


### PR DESCRIPTION
The previous tag was using an experimental branch where asset files were named `custom.js` and `custom.css`. This update points to the main branch, which includes the renamed files: `external.js` and `external.css`.