### PR TITLE
Remove EZBorrow links from landing pages

### DIFF
--- a/e2e/tests/golden/01NYU_AD-AD/home-page.html
+++ b/e2e/tests/golden/01NYU_AD-AD/home-page.html
@@ -79,7 +79,7 @@
             <p>Visit the <a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank" class="md-primoExplore-theme">Using NYUAD Library's Catalog guide</a> for tips on searching the catalog and getting library resources.</p>
             <h3 class="md-subhead">Additional Resources</h3>
             <ul>
-                <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank" class="md-primoExplore-theme">EZBorrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials unavailable at NYU</li>
+                <li>Use <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">Interlibrary Loan (ILL)</a> for materials unavailable at NYU</li>
                 <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank" class="md-primoExplore-theme">expert-curated research guides</a></li>
                 <li>Explore library services available through our <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/faculty-resources.html" target="_blank">faculty and staff resources</a>, and <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/student-resources.html" target="_blank">student resources</a></li>
                 <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank" class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>

--- a/e2e/tests/golden/01NYU_AD-AD/home-page.txt
+++ b/e2e/tests/golden/01NYU_AD-AD/home-page.txt
@@ -18,7 +18,7 @@ Use Ask A Librarian or the "Chat with Us" icon at the bottom right corner for an
 Visit our online tutorials for tips on searching the catalog and getting library resources.
 
 Additional Resources
-Use EZBorrow or InterLibrary Loan (ILL) for materials unavailable at NYU
+Use Interlibrary Loan (ILL) for materials unavailable at NYU
 Discover subject specific resources using expert curated research guides
 Explore the complete list of library services
 Reach out to the Libraries on our Instagram

--- a/e2e/tests/golden/01NYU_INST-NYU/home-page.html
+++ b/e2e/tests/golden/01NYU_INST-NYU/home-page.html
@@ -87,7 +87,7 @@
             <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">online tutorials</a> for tips on searching the catalog and getting library resources.</p>
             <h3 class="md-subhead">Additional Resources</h3>
             <ul>
-                <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank" class="md-primoExplore-theme">EZBorrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials
+                <li>Use <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">Interlibrary Loan (ILL)</a> for materials
                     unavailable at NYU</li>
                 <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank" class="md-primoExplore-theme">expert curated research guides</a></li>
                 <li>Explore the <a href="https://library.nyu.edu/services/" target="_blank" class="md-primoExplore-theme">complete list of library services</a></li>
@@ -111,7 +111,7 @@
                 <li>If an item says “Available” at an Offsite location, use the “Request Physical Copy” or “Request Scan” options under the GetIt section of the record in the catalog record.</li>
             </ul>
             <p>Locker pick-up, delivery, or digital scanning is also available, but may not be your fastest options. For details, visit the <a href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank">Collections Access page</a>.</p>
-            <p>If an item says <b>“Out of library”</b>, you can use the <il>“Request from partner libraries”</il> link in the catalog record. This initiates an <a href="https://ezborrow.reshare.indexdata.com/" target="_blank">EZborrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank">Interlibrary Loan (ILL)</a> request.
+            <p>If an item says <b>“Out of library”</b>, you can use the <il>“Request from partner libraries”</il> link in the catalog record. This initiates an <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank">Interlibrary Loan (ILL)</a> request.
 
             </p>
             <h3 class="md-subhead">What option should I choose?</h3>

--- a/e2e/tests/golden/01NYU_INST-NYU/home-page.txt
+++ b/e2e/tests/golden/01NYU_INST-NYU/home-page.txt
@@ -18,7 +18,7 @@ Use Ask A Librarian or the "Chat with Us" icon at the bottom right corner for an
 Visit our online tutorials for tips on searching the catalog and getting library resources.
 
 Additional Resources
-Use EZBorrow or InterLibrary Loan (ILL) for materials unavailable at NYU
+Use Interlibrary Loan (ILL) for materials unavailable at NYU
 Discover subject specific resources using expert curated research guides
 Explore the complete list of library services
 Reach out to the Libraries on our Instagram

--- a/primo-customization/01NYU_AD-AD/html/_static/homepage_en-external.html
+++ b/primo-customization/01NYU_AD-AD/html/_static/homepage_en-external.html
@@ -76,7 +76,7 @@
                 <p>Visit the <a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank" class="md-primoExplore-theme">Using NYUAD Library's Catalog guide</a> for tips on searching the catalog and getting library resources.</p>
                 <h3 class="md-subhead">Additional Resources</h3>
                 <ul>
-                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank" class="md-primoExplore-theme">EZBorrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials unavailable at NYU</li>
+                    <li>Use <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">Interlibrary Loan (ILL)</a> for materials unavailable at NYU</li>
                     <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank" class="md-primoExplore-theme">expert-curated research guides</a></li>
                     <li>Explore library services available through our <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/faculty-resources.html" target="_blank">faculty and staff resources</a>, and <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/student-resources.html" target="_blank">student resources</a></li>
                     <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank" class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
@@ -99,7 +99,6 @@
     </md-card>
     </div>
 </md-content>
-
 
 
 

--- a/primo-customization/01NYU_INST-NYU/html/_static/homepage_en-external.html
+++ b/primo-customization/01NYU_INST-NYU/html/_static/homepage_en-external.html
@@ -81,7 +81,7 @@
                 <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">online tutorials</a> for tips on searching the catalog and getting library resources.</p>
                 <h3 class="md-subhead">Additional Resources</h3>
                 <ul>
-                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank" class="md-primoExplore-theme">EZBorrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials
+                    <li>Use <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">Interlibrary Loan (ILL)</a> for materials
                         unavailable at NYU</li>
                     <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank" class="md-primoExplore-theme">expert curated research guides</a></li>
                     <li>Explore the <a href="https://library.nyu.edu/services/" target="_blank" class="md-primoExplore-theme">complete list of library services</a></li>
@@ -103,7 +103,7 @@
                 <ul><li>If an item says “Available” in one of our libraries (not including an “Offsite” location, you may get it  directly from the stacks.</li>
                     <li>If an item says “Available” at an Offsite location, use the “Request Physical Copy” or “Request Scan” options under the GetIt section of the record in the catalog record.</li>
                 </ul>
-                <p>Locker pick-up, delivery, or digital scanning is also available, but may not be your fastest options. For details, visit the <a href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank">Collections Access page</a>.</p><p>If an item says <b>“Out of library”</b>, you can use the <il>“Request from partner libraries”</il> link in the catalog record. This initiates an <a href="https://ezborrow.reshare.indexdata.com/" target="_blank">EZborrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank">Interlibrary Loan (ILL)</a> request.
+                <p>Locker pick-up, delivery, or digital scanning is also available, but may not be your fastest options. For details, visit the <a href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank">Collections Access page</a>.</p><p>If an item says <b>“Out of library”</b>, you can use the <il>“Request from partner libraries”</il> link in the catalog record. This initiates an <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank">Interlibrary Loan (ILL)</a> request.
 
             </p><h3 class="md-subhead">What option should I choose?</h3>
                 <ul>


### PR DESCRIPTION
Re:https://nyu-lib.monday.com/boards/765008773/pulses/12067615703

## Summary
- Removes EZBorrow/VuFind links from NYU-NY and NYU Abu Dhabi landing page Additional Resources copy.
- Updates NYU-NY Collections Access copy so partner-library requests are described as Interlibrary Loan requests.
- Updates matching e2e golden files for the affected landing pages.