### PR TITLE
Bump CircleCI executor to cimg/aws:2026.04.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 docker-defaults: &docker-defaults
   docker:
-    - image: cimg/aws:2024.03
+    - image: cimg/aws:2026.04.1
   working_directory: ~/app
 
 asset_sanity_check: &asset_sanity_check


### PR DESCRIPTION
Updates the CI executor image from `cimg/aws:2024.03` (~2 years old) to the current `2026.04.1`, picking up newer AWS CLI, Docker, and base-OS/security patches.
`cimg/aws` bundles the AWS CLI, which the deploy jobs use for real S3 work (`aws s3 cp / aws s3 sync --delete` in `config.yml`). A CLI version bump can subtly change s3 sync behavior, so this is isolated from the e2e dockerignore change #260 