### PR TITLE
Fix `docker compose pull` failing on locally-built images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
+# The `primo-customization-cdn-*` images are built locally and never published to a
+# registry, so a bare `docker compose pull` fails on them with "pull access denied".
+# `pull_policy: never` makes `pull` skip them; `up` still builds them when absent.
 x-build-e2e: &x-build-e2e
   image: primo-customization-cdn-e2e
+  pull_policy: never
   build:
     context: ./
     dockerfile: e2e/Dockerfile
@@ -7,11 +11,12 @@ x-build-e2e: &x-build-e2e
       - primo-customization-cdn-e2e
 
 x-environment: &x-environment
-  VIEW: ${VIEW}
+  VIEW: ${VIEW:-}
 
 services:
   cdn-server:
     image: primo-customization-cdn-cdn-server
+    pull_policy: never
     build:
       dockerfile: Dockerfile.cdn-server
     ports:
@@ -79,6 +84,7 @@ services:
   # services for local tls, i.e. for login
   tls:
     image: primo-customization-cdn-tls-nginx
+    pull_policy: never
     build:
       dockerfile: Dockerfile.nginx
     ports:


### PR DESCRIPTION
The `primo-customization-cdn-*` tags are never pushed to a registry, so `pull` failed with "pull access denied". `pull_policy: never` skips them; `up` and `run` still build them when absent. Also default `VIEW` to empty to silence the warnings from the README's `pull` line.

`docker compose pull`, the first command in the README, has never worked:

```
! primo-customization-cdn-tls-nginx   pull access denied ... repository does not exist
! primo-customization-cdn-e2e         pull access denied ... repository does not exist
! primo-customization-cdn-cdn-server  pull access denied ... repository does not exist
WARN[0000] The "VIEW" variable is not set. Defaulting to a blank string.   (x6)
```

Verified after the change: bare `docker compose pull` exits clean, skipping all four buildable images and pulling only `quay.io/nyulibraries/primo-customization-devenv:main`, with no `VIEW` warnings.

CI is unaffected. `pull_policy: never` does not disable building — confirmed that CI's exact command, `docker-compose run e2e`, still builds `primo-customization-cdn-e2e` when the image is absent.

