### PR TITLE
Match NYUAD banner height to the NYUSH view

### DIFF
--- a/primo-customization/01NYU_AD-AD/css/external.css
+++ b/primo-customization/01NYU_AD-AD/css/external.css
@@ -7,9 +7,11 @@ Do not move or alter the import order   */
 @import url("../../00_common/css/nyu_menu.css");
 
 
-/* Enlarge top bar to resize the NYUAD logo so it's readable */
+/* Size the top bar to match the NYUSH view. Primo's own
+   `prm-logo .product-logo` supplies height: 100% and padding: 0.85em,
+   which is what sets the logo's clear space, so no override is needed here. */
 prm-topbar {
-    height: 150px;
+    height: 80px;
 }
 
 
@@ -17,18 +19,6 @@ prm-topbar {
 prm-logo .product-logo .organization-logo:hover,
 a:hover {
     box-shadow: none !important;
-}
-
-
-/* Align the logo horizontally and vertically */
-prm-logo .product-logo {
-    display: flex;
-}
-
-.product-logo {
-    justify-content: center;
-    align-items: center;
-    height: 100%;
 }
 
 


### PR DESCRIPTION
Re: https://nyu-lib.monday.com/boards/765008773/pulses/12589904232

Addresses the third acceptance criterion on the NYUAD story — "update the banner height to match the left alignment and padding of the NYUSH view."

## What changed

`prm-topbar` goes from 150px to 80px, matching NYUSH, and the flex-centering override is removed.
